### PR TITLE
Load simplycode through npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "echo \"test not implemented yet\" && exit 1",
     "start": "electron-forge start",
     "package": "electron-forge package",
-    "make": "electron-forge make"
+    "make": "electron-forge make",
+    "postinstall": "scripts/post-install.sh"
   },
   "keywords": [
     "javascript",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "electron": "^30.0.2"
   },
   "dependencies": {
-    "electron-squirrel-startup": "^1.0.1"
+    "electron-squirrel-startup": "^1.0.1",
+    "simplycode": "github:simplyedit/simplycode"
   }
 }

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+installSimplyCode() {
+    local sSourceDir sTargetDir
+
+    readonly sSourceDir="${npm_config_local_prefix}/node_modules/simplycode/www"
+    readonly sTargetDir="${npm_config_local_prefix}/simplycode"
+
+    cp -fR  "${sSourceDir}" "${sTargetDir}"
+}
+
+if [[ ${BASH_SOURCE[0]} != "${0}" ]]; then
+    export -f installSimplyCode
+else
+    installSimplyCode
+    exit $?
+fi


### PR DESCRIPTION
This MR adds logic to load SimplyCode from GitHub, using NPM, rather than having a copy.

This is done by adding a post `npm install` hook that move the content of the SimplyCode `www` directory to a `simplycode` directory in the root of the project (where the copy currently lives).

To test this before https://github.com/SimplyEdit/simplycode/pull/33 is merged, change the `dependencies` entry for simplycode to read:

```
    "simplycode": "github:simplyedit/simplycode#deploy/npm"
```

Then run `nmp install`. This will update the contents of the `simplycode/` directory.

At a later time, the SimplyCode code directory could be removed and added to the `.gitignore` file if desired.
This would keep the copy of the code completely out of this repo.
