### PR TITLE
Vscode debug configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+    "version": "0.2.0",
+    "compounds": [
+      {
+        "name": "Main + renderer",
+        "configurations": ["Main", "Renderer"],
+        "stopAll": true
+      }
+    ],
+    "configurations": [
+      {
+        "name": "Renderer",
+        "port": 9222,
+        "request": "attach",
+        "type": "chrome",
+        "webRoot": "${workspaceFolder}"
+      },
+      {
+        "name": "Main",
+        "type": "node",
+        "request": "launch",
+        "cwd": "${workspaceFolder}",
+        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
+        "windows": {
+          "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
+        },
+        "args": [".", "--remote-debugging-port=9222"],
+        "outputCapture": "std",
+        "console": "integratedTerminal"
+      }
+    ]
+  }

--- a/README.md
+++ b/README.md
@@ -6,3 +6,9 @@ To build:
 npm install
 npm run make
 ```
+
+Debugging in vscode:
+added launch.json file in .vscode to enable debugging with vscode as documented on [electron documentation](https://www.electronjs.org/docs/latest/tutorial/tutorial-first-app#optional-debugging-from-vs-code)
+```
+The "Main + renderer" option will appear when you select "Run and Debug" from the sidebar, allowing you to set breakpoints and inspect all the variables among other things in both the main and renderer processes.
+```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ npm install
 npm run make
 ```
 
-Debugging in vscode:
+Debugging in vscode: 
+
 added launch.json file in .vscode to enable debugging with vscode as documented on [electron documentation](https://www.electronjs.org/docs/latest/tutorial/tutorial-first-app#optional-debugging-from-vs-code)
 ```
 The "Main + renderer" option will appear when you select "Run and Debug" from the sidebar, allowing you to set breakpoints and inspect all the variables among other things in both the main and renderer processes.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ npm run make
 
 Debugging in vscode: 
 
-added launch.json file in .vscode to enable debugging with vscode as documented on [electron documentation](https://www.electronjs.org/docs/latest/tutorial/tutorial-first-app#optional-debugging-from-vs-code)
+Debugging with vscode is possible as documented on [electron documentation](https://www.electronjs.org/docs/latest/tutorial/tutorial-first-app#optional-debugging-from-vs-code)
 ```
 The "Main + renderer" option will appear when you select "Run and Debug" from the sidebar, allowing you to set breakpoints and inspect all the variables among other things in both the main and renderer processes.
 ```

--- a/main.js
+++ b/main.js
@@ -12,6 +12,7 @@ const createWindow = () => {
     const win = new BrowserWindow({
       width: 1024,
       height: 786,
+      title: "Simply Code",
       webPreferences: {
         preload: path.join(__dirname, 'preload.js'),
         webSecurity: false,
@@ -20,6 +21,21 @@ const createWindow = () => {
     })
   
     win.loadURL('simplycode://index.html')
+}
+
+const createSecondWindow = (dataDir) => {
+    const win2 = new BrowserWindow({
+      width: 1024,
+      height: 786,
+      title: "My App",
+      webPreferences: {
+        preload: path.join(__dirname, 'preload.js'),
+        webSecurity: false,
+        allowRunningInsecureContent : true
+      }
+    })
+  
+    win2.loadURL('simplyapp://generated.html')
 }
 
 function readRecursive(componentPath) { 
@@ -79,6 +95,17 @@ app.commandLine.appendSwitch('disable-site-isolation-trials');
 protocol.registerSchemesAsPrivileged([
     {
       scheme: 'simplycode',
+      privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true
+      }
+    }
+])
+
+protocol.registerSchemesAsPrivileged([
+    {
+      scheme: 'simplyapp',
       privileges: {
         standard: true,
         secure: true,
@@ -184,6 +211,46 @@ app.whenReady().then(() => {
                 break    
             }
         }
+
+        
+    })
+
+    protocol.handle('simplyapp', (request) => {
+        let componentPath = new URL(request.url).pathname
+        console.log('simplyapp:' + componentPath)
+        if(componentPath.endsWith('\/')){
+            componentPath = componentPath.substring(0, (componentPath.length - 1))
+        }
+        
+        let pathicles = componentPath.split('\/');
+        let componentName = pathicles.pop();
+        let componentDirectory = pathicles.join('/');
+        pathicles.shift();
+
+     
+        switch (request.method){
+            default:
+                if(componentPath.endsWith('\/')){
+                    componentPath = componentPath.substring(0, (componentPath.length - 1))
+                }
+
+                if (!componentPath || componentPath === "/") {
+                    const filestuff = fs.readFileSync(dataDir + '/generated.html')
+                    return new Response(filestuff, {
+                        // headers: { 'content-type': 'text/html' }
+                    })
+                } else {
+                    const filestuff = fs.readFileSync(dataDir + componentDirectory + '\/' + componentName)
+                    return new Response(filestuff, {
+                        // headers: { 'content-type': 'text/html' }
+                    })
+                }    
+            break    
+        }
+        
+        
+
+        
     })
 
     dataDir = dialog.showOpenDialogSync({properties: ['openDirectory']})[0];
@@ -192,6 +259,7 @@ app.whenReady().then(() => {
         dataDir += "/";
     }
     createWindow()
+    createSecondWindow(dataDir)
 
     app.on('activate', () => {
         if (BrowserWindow.getAllWindows().length === 0) {
@@ -200,6 +268,7 @@ app.whenReady().then(() => {
                 dataDir += "/";
             }
             createWindow()
+            createSecondWindow(dataDir)
         }
     })
     

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "echo \"test not implemented yet\" && exit 1",
     "start": "electron-forge start",
     "package": "electron-forge package",
-    "make": "electron-forge make"
+    "make": "electron-forge make",
+    "postinstall": "scripts/post-install.sh"
   },
   "keywords": [
     "javascript",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "electron": "^30.0.2"
   },
   "dependencies": {
-    "electron-squirrel-startup": "^1.0.1"
+    "electron-squirrel-startup": "^1.0.1",
+    "simplycode": "github:simplyedit/simplycode"
   }
 }

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+installSimplyCode() {
+    local sSourceDir sTargetDir
+
+    readonly sSourceDir="${npm_config_local_prefix}/node_modules/simplycode/www"
+    readonly sTargetDir="${npm_config_local_prefix}/simplycode"
+
+    cp -fR  "${sSourceDir}" "${sTargetDir}"
+}
+
+if [[ ${BASH_SOURCE[0]} != "${0}" ]]; then
+    export -f installSimplyCode
+else
+    installSimplyCode
+    exit $?
+fi


### PR DESCRIPTION
added launch file to enable debugging with vscode as documented on [electron documentation]( https://www.electronjs.org/docs/latest/tutorial/tutorial-first-app#optional-debugging-from-vs-code  
)
`The "Main + renderer" option will appear when you select "Run and Debug" from the sidebar, allowing you to set breakpoints and inspect all the variables among other things in both the main and renderer processes.`