### PR TITLE
fix script path so it copies the contents of www/* instead of www

### DIFF
--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -6,7 +6,7 @@ installSimplyCode() {
     readonly sSourceDir="${npm_config_local_prefix}/node_modules/simplycode/www"
     readonly sTargetDir="${npm_config_local_prefix}/simplycode"
 
-    cp -fR  "${sSourceDir}" "${sTargetDir}"
+    cp -a  "${sSourceDir}" "${sTargetDir}"
 }
 
 if [[ ${BASH_SOURCE[0]} != "${0}" ]]; then


### PR DESCRIPTION
I noticed the files were getting copied into simplycode/www instead of directly under simplycode.