### PR TITLE
Fix forge config

### DIFF
--- a/.github/workflows/make-mac.yml
+++ b/.github/workflows/make-mac.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -18,7 +18,7 @@ jobs:
       # You can test your matrix by printing the current Python version
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"
-    - uses: actions/setup-node@master
+    - uses: actions/setup-node@v4
       with:
         node-version: 20
     - name: install dependencies

--- a/.github/workflows/make-mac.yml
+++ b/.github/workflows/make-mac.yml
@@ -28,6 +28,8 @@ jobs:
 
     - name: Publish app
       run: npm run publish
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # build:
   #   strategy:

--- a/forge.config.js
+++ b/forge.config.js
@@ -3,28 +3,24 @@ const { FuseV1Options, FuseVersion } = require('@electron/fuses');
 const path = require('path');
 
 module.exports = {
-  packagerConfig: {
-    asar: true,
-  },
-  rebuildConfig: {},
   makers: [
     {
       name: '@electron-forge/maker-squirrel',
-      platforms: ['darwin', 'linux', 'windows'],
+      platforms: ['linux', 'windows'],
       config: {
         bin: 'simplycode',
       }
     },
     {
       name: '@electron-forge/maker-dmg',
-      platforms: ['darwin', 'linux'],
+      platforms: ['darwin'],
       config: {
         bin: 'simplycode',
       },
     },
     {
       name: '@electron-forge/maker-deb',
-      platforms: ['darwin', 'linux'],
+      platforms: ['linux'],
       config: {
         bin: 'simplycode',
         options: {
@@ -33,28 +29,11 @@ module.exports = {
     },
     {
       name: '@electron-forge/maker-rpm',
-      platforms: ['darwin', 'linux'],
+      platforms: ['linux'],
       config: {
         bin: 'simplycode',
       }
     }
-  ],
-  plugins: [
-    {
-      name: '@SimplyEdit/simplycode-electron/tree/electron-forge-github-actions',
-      config: {},
-    },
-    // Fuses are used to enable/disable various Electron functionality
-    // at package time, before code signing the application
-    new FusesPlugin({
-      version: FuseVersion.V1,
-      [FuseV1Options.RunAsNode]: false,
-      [FuseV1Options.EnableCookieEncryption]: true,
-      [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
-      [FuseV1Options.EnableNodeCliInspectArguments]: false,
-      [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
-      [FuseV1Options.OnlyLoadAppFromAsar]: true,
-    }),
   ],
   publishers: [
     {
@@ -68,4 +47,4 @@ module.exports = {
       }
     }
   ]
-};
+}

--- a/package.json
+++ b/package.json
@@ -45,51 +45,6 @@
     "simplycode": "github:simplyedit/simplycode"
   },
   "config": {
-    "forge": {
-      "makers": [
-          {
-            "name": "@electron-forge/maker-squirrel",
-            "platforms": ["linux", "windows"],
-            "config": {
-              "bin": "simplycode"
-            }
-          },
-          {
-            "name": "@electron-forge/maker-dmg",
-            "platforms": ["darwin"],
-            "config": {
-              "bin": "simplycode"
-            }
-          },
-          {
-            "name": "@electron-forge/maker-deb",
-            "platforms": ["linux"],
-            "config": {
-              "bin": "simplycode",
-              "options": {
-              }
-            }
-          },
-          {
-            "name": "@electron-forge/maker-rpm",
-            "platforms": ["linux"],
-            "config": {
-              "bin": "simplycode"
-            }
-          }
-      ],
-      "publishers": [
-        {
-        "name": "@electron-forge/publisher-github",
-        "config": {
-          "repository": {
-            "owner": "SimplyEdit",
-            "name": "simplycode-electron"
-          },
-          "prerelease": true
-        }
-      }
-    ]
-    }
+    "forge": "forge.config.js"
   }
 }


### PR DESCRIPTION
This MR changes the current effort to make the publish GitHub Action (GHA) work.

Changes needed to make things work:

1. Set `GITHUB_TOKEN` on the env
    ```yaml
      env:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    ```

Changes included but not needed:

1. Change GitHub Actions to latest versioned versions
2. Change `package.json` to run `forge.config.js` instead of inline config

Working run can be seen at: [potherca-contrib/simplycode-electron:10743024196/job/29796902761][1]
Result can be seen at: [potherca-contrib/simplycode-electron@untagged-3214821d8b67743f12c5][2]

[1]: https://github.com/potherca-contrib/simplycode-electron/actions/runs/10743024196/job/29796902761
[2]: https://github.com/potherca-contrib/simplycode-electron/releases/tag/untagged-3214821d8b67743f12c5