### PR TITLE
Fix release version not being set

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,21 +18,17 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 22
+      - name: Set version from release tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "Setting version to $VERSION"
+          npm version $VERSION --no-git-tag-version
       - name: install dependencies
         run: npm install
       - name: publish
         run: npm run publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload Linux artifacts
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            out/make/deb/**/*.deb
-            out/make/rpm/**/*.rpm
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
 
   publish_for_mac:
     runs-on: macos-latest
@@ -41,17 +37,15 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 22
+      - name: Set version from release tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "Setting version to $VERSION"
+          npm version $VERSION --no-git-tag-version
       - name: install dependencies
         run: npm install
       - name: publish
         run: npm run publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload macOS artifact to release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            out/make/*.dmg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -62,17 +56,14 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 22
+      - name: Set version from release tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "Setting version to $VERSION"
+          npm version $VERSION --no-git-tag-version
       - name: install dependencies
         run: npm install
       - name: publish
         run: npm run publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload Windows artifacts
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            out/make/squirrel.windows/**/*.exe
-            out/make/msi/**/*.msi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,11 +18,9 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 22
-      - name: Set version from release tag
+      - name: Set version from release name
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "Setting version to $VERSION"
-          npm version $VERSION --no-git-tag-version
+          npm version "${{ github.event.release.name }}" --no-git-tag-version
       - name: install dependencies
         run: npm install
       - name: publish
@@ -37,11 +35,9 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 22
-      - name: Set version from release tag
+      - name: Set version from release name
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "Setting version to $VERSION"
-          npm version $VERSION --no-git-tag-version
+          npm version "${{ github.event.release.name }}" --no-git-tag-version
       - name: install dependencies
         run: npm install
       - name: publish
@@ -56,11 +52,9 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 22
-      - name: Set version from release tag
+      - name: Set version from release name
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "Setting version to $VERSION"
-          npm version $VERSION --no-git-tag-version
+          npm version "${{ github.event.release.name }}" --no-git-tag-version
       - name: install dependencies
         run: npm install
       - name: publish


### PR DESCRIPTION
So... Turns out the Electron Forge reads the version from the `package.json`. Since we do not set the version there (we use git instead), the publish command does not find a version. Hence the `vundefined` release and the `0.0.0` filenames.

This MR uses the `npm version` command to set the "version" key in the `package.json` to the value of the release's name. (Taken from the release event).